### PR TITLE
Add num_splits property to BaseRegressor base class

### DIFF
--- a/mlguess/keras/models.py
+++ b/mlguess/keras/models.py
@@ -62,7 +62,8 @@ class BaseRegressor(object):
         save_path=".",
         model_name="model.h5",
         metrics=None,
-        eps=1e-7
+        eps=1e-7,
+        num_splits=1
     ):
         self.hidden_layers = hidden_layers
         self.hidden_neurons = hidden_neurons
@@ -95,6 +96,7 @@ class BaseRegressor(object):
         self.eps = eps
         self.ensemble_member_files = []
         self.history = None
+        self.num_splits = num_splits
 
     def build_neural_network(self, inputs, outputs, last_layer="Dense"):
         """
@@ -307,22 +309,22 @@ class BaseRegressor(object):
 
     def mae(self, y_true, y_pred):
         """ Compute the MAE """
-        num_splits = y_pred.shape[-1]
-        if num_splits == 4:
-            mu, _, _, _ = tf.split(y_pred, num_splits, axis=-1)
-        elif num_splits == 2:
-            mu, _ = tf.split(y_pred, num_splits, axis=-1)
+        # num_splits = y_pred.shape[-1]
+        if self.num_splits == 4:
+            mu, _, _, _ = tf.split(y_pred, self.num_splits, axis=-1)
+        elif self.num_splits == 2:
+            mu, _ = tf.split(y_pred, self.num_splits, axis=-1)
         else:
             mu = y_pred  # Assuming num_splits is 1
         return tf.keras.metrics.mean_absolute_error(y_true, mu)
 
     def mse(self, y_true, y_pred):
         """ Compute the MSE """
-        num_splits = y_pred.shape[-1]
-        if num_splits == 4:
-            mu, _, _, _ = tf.split(y_pred, num_splits, axis=-1)
-        elif num_splits == 2:
-            mu, _ = tf.split(y_pred, num_splits, axis=-1)
+        # num_splits = y_pred.shape[-1]
+        if self.num_splits == 4:
+            mu, _, _, _ = tf.split(y_pred, self.num_splits, axis=-1)
+        elif self.num_splits == 2:
+            mu, _ = tf.split(y_pred, self.num_splits, axis=-1)
         else:
             mu = y_pred  # Assuming num_splits is 1
 
@@ -612,6 +614,7 @@ class GaussianRegressorDNN(BaseRegressor):
             save_path,
             model_name,
             metrics,
+            num_splits = 2
         )
         self.eps = eps
         self.loss = GaussianNLL
@@ -796,6 +799,7 @@ class EvidentialRegressorDNN(BaseRegressor):
             save_path,
             model_name,
             metrics,
+            num_splits=4
         )
         self.coupling_coef = coupling_coef
         self.evidential_coef = evidential_coef


### PR DESCRIPTION

The BaseRegressor base class for regression models needs to split outputs based on the model in use (e.g. `EvidentialRegressorDNN` needs 4, `GaussianRegressorDNN` 2).  The way the splits are currently determined (based on the last dimension of `y_pred`) only works if the NN output is a scalar.  For vector outputs, this approach fails.  

I added a `num_splits` kwarg to the `BaseRegressor` class which is stored as a property of the class and used to split model outputs into the respective mean, variance, etc when losses are computed.  When the derived class inits the base class, this number is hardcoded in (e.g. `EvidentialRegressorDNN` sets this to 4).

This change allows me to train a NN with a 1D vector of outputs.